### PR TITLE
improved coloring/wrapping/folding for sls files

### DIFF
--- a/ftplugin/sls.vim
+++ b/ftplugin/sls.vim
@@ -2,3 +2,32 @@
 set expandtab
 set softtabstop=2
 set shiftwidth=2
+" do not display right side colorcolumn
+set colorcolumn=
+
+" do not wrap YAML,  but autowrap long comment lines!
+set wrap
+set fo-=tor
+" t -> don't wrap text 
+" o -> don't add comment leader on o/O
+" r -> don't add comment leader after an Enter
+
+
+" folding
+set foldmethod=indent
+set foldlevel=6  " by default do not fold anything
+
+
+" Visual warning about UTF8 characters in SLS file.
+" salt does not like them much, so they should be red
+augroup utfsls
+  autocmd!
+  highlight UTFsls ctermbg=red guibg=red
+  match UTFsls /[\x7F-\xFF]/
+  autocmd BufWinEnter * match UTFsls /[\x7F-\xFF]/
+  autocmd InsertEnter * match UTFsls /[\x7F-\xFF]/
+  autocmd InsertLeave * match UTFsls /[\x7F-\xFF]/
+  autocmd BufWinLeave * call clearmatches()
+augroup END
+
+


### PR DESCRIPTION
- do not use colorcolumn (if set by default)
- text is not wrapped, but comments are!
- pressing enter will not start next line with comment
- enabled folding (based on indent)
- show utf8 characters with red background, they are errors!
