### PR TITLE
added automatic  indentation for vim 

### DIFF
--- a/ftplugin/sls.vim
+++ b/ftplugin/sls.vim
@@ -1,24 +1,47 @@
 " Use two-spaces for indentation
-set expandtab
-set softtabstop=2
-set shiftwidth=2
+setlocal expandtab
+setlocal softtabstop=2
+setlocal shiftwidth=2
 " do not display right side colorcolumn
-set colorcolumn=
+setlocal colorcolumn=
 
 " do not wrap YAML,  but autowrap long comment lines!
-set wrap
-set fo-=tor
+setlocal wrap
+setlocal fo-=tor
 " t -> don't wrap text 
-" o -> don't add comment leader on o/O
-" r -> don't add comment leader after an Enter
+" o -> don't add comment leader on o/O
+" r -> don't add comment leader after an Enter
 
+
+" indentation
+setlocal autoindent
+
+" This function is from https://gist.github.com/871107
+" Author: Ian Young
+"
+function! GetYamlIndent()
+  let lnum = v:lnum - 1
+  if lnum == 0
+    return 0
+  endif
+  let line = substitute(getline(lnum),'\s\+$','','')
+  let indent = indent(lnum)
+  let increase = indent + &sw
+  if line =~ ':$'
+    return increase
+  else
+    return indent
+  endif
+endfunction
+
+setlocal indentexpr=GetYamlIndent()
 
 " folding
-set foldmethod=indent
-set foldlevel=6  " by default do not fold anything
+setlocal foldmethod=indent
+setlocal foldlevel=6  " by default do not fold anything
 
 
-" Visual warning about UTF8 characters in SLS file.
+" Visual warning about UTF8 characters in SLS file.
 " salt does not like them much, so they should be red
 augroup utfsls
   autocmd!


### PR DESCRIPTION
now vim will do autoindent in sls files
when line ends with ':', the next line will be indented 2 spaces.

minor changes:
-  some utf8 characters were removed from the .vim file
-  using setlocal instead of set
