### PR TITLE
Colorcolumn is only in vim 7.3

### DIFF
--- a/ftplugin/sls.vim
+++ b/ftplugin/sls.vim
@@ -3,7 +3,9 @@ setlocal expandtab
 setlocal softtabstop=2
 setlocal shiftwidth=2
 " do not display right side colorcolumn
-setlocal colorcolumn=
+if version >= 703
+    setlocal colorcolumn=
+endif
 
 setlocal wrap
 


### PR DESCRIPTION
Colorcolumn is only used in vim 7.3 if you use 7.2 or earlier it will cause a issue
