### PR TITLE
Delimeter for NERDCommenter

### DIFF
--- a/syntax/sls.vim
+++ b/syntax/sls.vim
@@ -23,6 +23,10 @@ let b:current_syntax = ''
 unlet b:current_syntax
 syntax include @Jinja syntax/django.vim
 
+let g:NERDCustomDelimiters = { 
+  \ 'sls': { 'left': '#' },
+\ }
+
 syn cluster djangoBlocks add=djangoTagBlock,djangoVarBlock,djangoComment,djangoComBlock
 syn region djangoTagBlock start="{%" end="%}" contains=djangoStatement,djangoFilter,djangoArgument,djangoTagError display containedin=ALLBUT,@djangoBlocks
 syn region djangoVarBlock start="{{" end="}}" contains=djangoFilter,djangoArgument,djangoVarError display containedin=ALLBUT,@djangoBlocks


### PR DESCRIPTION
NERDCommenter isn't detecting `.sls` files as yaml or inheriting the `#` delimeter from the yaml syntax.

I put the above diff in my `.vimrc` as a stop gap to give support for yaml nerdcommenting.
