### PR TITLE
Updated README.rst due to error with later (or perhaps really old??) version of vim

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,19 @@ You will also need to specify the following settings in your ``~/.vimrc``::
     set nocompatible
     filetype plugin indent on
 
+Note: It's possible you may be presented with an error stating something
+similar to:
+
+"E319: Sorry, the command is not available in this version: filetype plugin inden
+t on"
+
+If you get this, specify the following settings in your ``~/.vimrc`` instead::
+
+    set nocompatible
+    set tabstop=2
+    set shiftwidth=2
+    set expandtab
+
 Alternately, files can be copied into any other directory where vim looks for
 its runtime files, like ``/etc/vim/``. Command ``:set runtimepath`` will show
 all such paths. Read ``:help runtimepath`` for more info.


### PR DESCRIPTION
I was getting "E319: Sorry, the command is not available in this version: filetype plugin indent on" messages and upon investigating further it seems the version I have is not the gui version, however it is the latest. massaging the file with slightly updated directives did the trick.

Was using a turnkey linux image, with all apt's update and upgraded. Using vim version "VIM - Vi IMproved 7.2 (2008 Aug 9, compiled Jul 12 2010 02:27:59)". Hope this helps.
