### PR TITLE
rewrite ftdetect to support #!py(dsl|objects)

### DIFF
--- a/ftdetect/sls.vim
+++ b/ftdetect/sls.vim
@@ -1,3 +1,11 @@
-if has("autocmd")
-  au  BufNewFile,BufRead *.sls set filetype=sls
-endif
+function! DetectSls()
+  if !did_filetype()
+    if match(getline(1), '^#!py') > -1
+      set ft=python
+    else
+      set ft=sls
+    endif
+  endif
+endfunction
+
+:au BufNewFile,BufRead *.sls call DetectSls()


### PR DESCRIPTION
There might be a better way of doing this, but this works for me at least.
