### PR TITLE
Removed reStructuredText ftplugin

### DIFF
--- a/ftplugin/rst.vim
+++ b/ftplugin/rst.vim
@@ -1,7 +1,0 @@
-" Use four spaces for indentation
-setlocal expandtab
-setlocal softtabstop=4
-setlocal shiftwidth=4
-
-" Wrap at 80 lines
-setlocal textwidth=79


### PR DESCRIPTION
@terminalmage this change ok with you?

It feels off to me to have a rST ftplugin along with unrelated Vim files. (This isn't the first place I'd look to track down where a particular rST setting was coming from.)

It might make sense to have a "salt-docs-vim" repo if we had a little more settings/content to fill it out. Extra rST keywords, and a `path` addition perhaps?
