### PR TITLE
Stop changing some settings

### DIFF
--- a/ftplugin/sls.vim
+++ b/ftplugin/sls.vim
@@ -2,12 +2,6 @@
 setlocal expandtab
 setlocal softtabstop=2
 setlocal shiftwidth=2
-" do not display right side colorcolumn
-if version >= 703
-    setlocal colorcolumn=
-endif
-
-setlocal wrap
 
 setlocal formatoptions=crl
 " r -> don't add comment leader after an Enter
@@ -39,7 +33,7 @@ setlocal indentexpr=GetYamlIndent()
 
 " folding
 setlocal foldmethod=indent
-setlocal foldlevel=6  " by default do not fold 
+setlocal foldlevel=6  " by default do not fold
 
 
 " Visual warning about UTF8 characters in SLS file.


### PR DESCRIPTION
I tracked some rouge settings to this plugin after I noticed my vim acting weird when editing SLS files. Two main changes:
1. Removed settings for colorcolumn and wrap. I can understand setting ts and other stuff to try to enforce certain style, but these settings only change the way text is displayed, so should probably be left to the user.
2. Removed a couple of key remaps for folding and indents. IMHO a syntax plugin really (really, really...) shouldn't be remapping keys, and the space remap in fact broke one of my other  plugins where I was already remapping space to do something else. Also, the gv remappings are almost pointeless, since you can just use `.` to repeat the last indentation over the same block of text.

Not that theres anything inherently wrong with the stuff I took out, it's just not related to providing SLS syntax support, so should probably be somewhere else.
