### PR TITLE
Conditionally use a Jinja syntax file instead of Django

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,35 @@ Alternately, files can be copied into any other directory where Vim looks for
 its runtime files, like ``/etc/vim/``. The command ``:set runtimepath`` will
 show all such paths. Read ``:help runtimepath`` for more info.
 
+Configuration
+=============
+
+By default, if Pathogen is installed, the syntax file will search for the
+existence of a Jinja syntax file (as described in the `Jinja docs`_ or via a
+`Vim bundle`_) in the ``runtimepath``, and load that if found. If it is not
+found or Pathogen is not installed, the Django template syntax file (which is
+slightly different, but bundled with Vim) will be used. You can force using
+either syntax file using the global variable ``g:sls_use_jinja_syntax``. If it
+is set, autodetection will be turned off.
+
+.. _Jinja docs: http://jinja.pocoo.org/docs/integration/#vim
+.. _Vim bundle: https://github.com/Glench/Vim-Jinja2-Syntax
+
+Valid values:
+
+``0``
+    Use the Django syntax file.
+
+``1``
+    Use the Jinja syntax file, regardless of whether it exists or not.
+
+Example section of ``~/.vimrc``:
+
+.. code-block:: vim
+
+    " Force using the Django template syntax file
+    let g:sls_use_jinja_syntax = 0
+
 Files
 =====
 

--- a/syntax/sls.vim
+++ b/syntax/sls.vim
@@ -21,15 +21,42 @@ syntax include @Yaml syntax/yaml.vim
 
 let b:current_syntax = ''
 unlet b:current_syntax
-syntax include @Jinja syntax/django.vim
+
+" Default to look for Jinja syntax file
+let s:load_jinja_syntax = 0
+let s:search_for_jinja_syntax = 1
+if exists("g:sls_use_jinja_syntax")
+  let s:search_for_jinja_syntax = 0
+  let s:load_jinja_syntax = g:sls_use_jinja_syntax
+end
+if s:search_for_jinja_syntax && exists("*pathogen#runtime_findfile")
+  let s:jinja_path = pathogen#runtime_findfile("syntax/jinja.vim", 1)
+  if s:jinja_path != ""
+    let s:load_jinja_syntax = 1
+  endif
+endif
+
+if s:load_jinja_syntax
+  syntax include @Jinja syntax/jinja.vim
+
+  syn cluster jinjaSLSBlocks add=jinjaTagBlock,jinjaVarBlock,jinjaComment
+  " Mostly copy/pasted from
+  " https://github.com/mitsuhiko/jinja2/blob/6b7c0c23/ext/Vim/jinja.vim
+  syn region jinjaTagBlock matchgroup=jinjaTagDelim start=/{%-\?/ end=/-\?%}/ containedin=ALLBUT,jinjaTagBlock,jinjaVarBlock,jinjaRaw,jinjaString,jinjaNested,jinjaComment,@jinjaSLSBlocks
+  syn region jinjaVarBlock matchgroup=jinjaVarDelim start=/{{-\?/ end=/-\?}}/ containedin=ALLBUT,jinjaTagBlock,jinjaVarBlock,jinjaRaw,jinjaString,jinjaNested,jinjaComment,@jinjaSLSBlocks
+  syn region jinjaComment matchgroup=jinjaCommentDelim start="{#" end="#}" containedin=ALLBUT,jinjaTagBlock,jinjaVarBlock,jinjaString,@jinjaSLSBlocks
+else
+  " Fall back to Django template syntax
+  syntax include @Jinja syntax/django.vim
+
+  syn cluster djangoBlocks add=djangoTagBlock,djangoVarBlock,djangoComment,djangoComBlock
+  syn region djangoTagBlock start="{%" end="%}" contains=djangoStatement,djangoFilter,djangoArgument,djangoTagError display containedin=ALLBUT,@djangoBlocks
+  syn region djangoVarBlock start="{{" end="}}" contains=djangoFilter,djangoArgument,djangoVarError display containedin=ALLBUT,@djangoBlocks
+  syn region djangoComBlock start="{#" end="#}" contains=djangoTodo containedin=ALLBUT,@djangoBlocks
+endif
 
 let g:NERDCustomDelimiters = {
   \ 'sls': { 'left': '#' },
 \ }
-
-syn cluster djangoBlocks add=djangoTagBlock,djangoVarBlock,djangoComment,djangoComBlock
-syn region djangoTagBlock start="{%" end="%}" contains=djangoStatement,djangoFilter,djangoArgument,djangoTagError display containedin=ALLBUT,@djangoBlocks
-syn region djangoVarBlock start="{{" end="}}" contains=djangoFilter,djangoArgument,djangoVarError display containedin=ALLBUT,@djangoBlocks
-syn region djangoComBlock start="{#" end="#}" contains=djangoTodo containedin=ALLBUT,@djangoBlocks
 
 let b:current_syntax = "sls"


### PR DESCRIPTION
Search for a Jinja syntax file if Pathogen is installed, and fall back to use
the Django template syntax otherwise. Also provides a documented global
variable to force using either.
