### PR TITLE
Slow yaml highlighting workaround

### DIFF
--- a/ftplugin/sls.vim
+++ b/ftplugin/sls.vim
@@ -50,4 +50,6 @@ augroup utfsls
 augroup END
 
 " Slow yaml highlighting workaround
-setlocal regexpengine=1
+if has('regexpengine')
+  setlocal regexpengine=1
+endif


### PR DESCRIPTION
The new regexp engine of Vim makes scrolling yaml/sls files extremely slow, and eats lots of CPU.
We have to fall back to the old one for the moment.

Closes #20
