### PR TITLE
Switch from has('regexpengine') to testing current setting value

### DIFF
--- a/ftplugin/sls.vim
+++ b/ftplugin/sls.vim
@@ -1,3 +1,8 @@
+" Slow yaml highlighting workaround
+if exists('+regexpengine') && ('&regexpengine' == 0)
+  setlocal regexpengine=1
+endif
+
 " Use two-spaces for indentation
 setlocal expandtab
 setlocal softtabstop=2
@@ -48,8 +53,3 @@ augroup utfsls
   autocmd InsertLeave * match UTFsls /[\x7F-\xFF]/
   autocmd BufWinLeave * call clearmatches()
 augroup END
-
-" Slow yaml highlighting workaround
-if has('regexpengine')
-  setlocal regexpengine=1
-endif


### PR DESCRIPTION
Tweak to the test in #21. `has('regexpengine')` returns `0` for me (Vim 7.4) but `exists()` works. Not sure why.

Tested on Vim 7.2 (that does not have `regexpengine` and Vim 7.4.
