### PR TITLE
Apply visual warnings only to sls buffers

### DIFF
--- a/ftplugin/sls.vim
+++ b/ftplugin/sls.vim
@@ -48,8 +48,8 @@ augroup utfsls
   autocmd!
   highlight UTFsls ctermbg=red guibg=red
   match UTFsls /[\x7F-\xFF]/
-  autocmd BufWinEnter * match UTFsls /[\x7F-\xFF]/
-  autocmd InsertEnter * match UTFsls /[\x7F-\xFF]/
-  autocmd InsertLeave * match UTFsls /[\x7F-\xFF]/
-  autocmd BufWinLeave * call clearmatches()
+  autocmd BufWinEnter <buffer> match UTFsls /[\x7F-\xFF]/
+  autocmd InsertEnter <buffer> match UTFsls /[\x7F-\xFF]/
+  autocmd InsertLeave <buffer> match UTFsls /[\x7F-\xFF]/
+  autocmd BufWinLeave <buffer> call clearmatches()
 augroup END


### PR DESCRIPTION
After opening an SLS file, the visual warnings are being applied also to other types of buffers.
This is a non desirable effect. This PR restricts the visual warnings only to SLS buffers.
