### PR TITLE
Add filetype detection for Saltfile

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,8 @@ Files
     - Visual warning for non-ASCII characters (which are not allowed in YAML).
 
 ``ftdetect/sls.vim``
-    Detect SLS file by the file extension ``.sls``.
+    Detect SLS files by the file extension ``.sls``, and ``Saltfile`` files by
+    an exact filename match.
 
 
 Other VIM plugins you might find interesting

--- a/ftdetect/sls.vim
+++ b/ftdetect/sls.vim
@@ -8,4 +8,4 @@ function! DetectSls()
   endif
 endfunction
 
-:au BufNewFile,BufRead *.sls call DetectSls()
+:au BufNewFile,BufRead *.sls,Saltfile call DetectSls()


### PR DESCRIPTION
Detects files named `Saltfile` and applies the same `sls` filetype to them, since Saltfiles are essentially the same.
