### PR TITLE
Add in jinja.vim as from  Jinja Integration docs

### DIFF
--- a/syntax/jinja.vim
+++ b/syntax/jinja.vim
@@ -1,0 +1,113 @@
+" Vim syntax file
+" Language:	Jinja template
+" Maintainer:	Armin Ronacher <armin.ronacher@active-4.com>
+" Last Change:	2008 May 9
+" Version:      1.1
+"
+" Known Bugs:
+"   because of odd limitations dicts and the modulo operator
+"   appear wrong in the template.
+"
+" Changes:
+"
+"     2008 May 9:     Added support for Jinja2 changes (new keyword rules)
+
+" For version 5.x: Clear all syntax items
+" For version 6.x: Quit when a syntax file was already loaded
+if version < 600
+  syntax clear
+elseif exists("b:current_syntax")
+  finish
+endif
+
+syntax case match
+
+" Jinja template built-in tags and parameters (without filter, macro, is and raw, they
+" have special threatment)
+syn keyword jinjaStatement containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained and if else in not or recursive as import
+
+syn keyword jinjaStatement containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained is filter skipwhite nextgroup=jinjaFilter
+syn keyword jinjaStatement containedin=jinjaTagBlock contained macro skipwhite nextgroup=jinjaFunction
+syn keyword jinjaStatement containedin=jinjaTagBlock contained block skipwhite nextgroup=jinjaBlockName
+
+" Variable Names
+syn match jinjaVariable containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained skipwhite /[a-zA-Z_][a-zA-Z0-9_]*/
+syn keyword jinjaSpecial containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained false true none loop super caller varargs kwargs
+
+" Filters
+syn match jinjaOperator "|" containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained nextgroup=jinjaFilter
+syn match jinjaFilter contained skipwhite /[a-zA-Z_][a-zA-Z0-9_]*/
+syn match jinjaFunction contained skipwhite /[a-zA-Z_][a-zA-Z0-9_]*/
+syn match jinjaBlockName contained skipwhite /[a-zA-Z_][a-zA-Z0-9_]*/
+
+" Jinja template constants
+syn region jinjaString containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained start=/"/ skip=/\\"/ end=/"/
+syn region jinjaString containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained start=/'/ skip=/\\'/ end=/'/
+syn match jinjaNumber containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained /[0-9]\+\(\.[0-9]\+\)\?/
+
+" Operators
+syn match jinjaOperator containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained /[+\-*\/<>=!,:]/
+syn match jinjaPunctuation containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained /[()\[\]]/
+syn match jinjaOperator containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained /\./ nextgroup=jinjaAttribute
+syn match jinjaAttribute contained /[a-zA-Z_][a-zA-Z0-9_]*/
+
+" Jinja template tag and variable blocks
+syn region jinjaNested matchgroup=jinjaOperator start="(" end=")" transparent display containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained
+syn region jinjaNested matchgroup=jinjaOperator start="\[" end="\]" transparent display containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained
+syn region jinjaNested matchgroup=jinjaOperator start="{" end="}" transparent display containedin=jinjaVarBlock,jinjaTagBlock,jinjaNested contained
+syn region jinjaTagBlock matchgroup=jinjaTagDelim start=/{%-\?/ end=/-\?%}/ skipwhite containedin=ALLBUT,jinjaTagBlock,jinjaVarBlock,jinjaRaw,jinjaString,jinjaNested,jinjaComment
+
+syn region jinjaVarBlock matchgroup=jinjaVarDelim start=/{{-\?/ end=/-\?}}/ containedin=ALLBUT,jinjaTagBlock,jinjaVarBlock,jinjaRaw,jinjaString,jinjaNested,jinjaComment
+
+" Jinja template 'raw' tag
+syn region jinjaRaw matchgroup=jinjaRawDelim start="{%\s*raw\s*%}" end="{%\s*endraw\s*%}" containedin=ALLBUT,jinjaTagBlock,jinjaVarBlock,jinjaString,jinjaComment
+
+" Jinja comments
+syn region jinjaComment matchgroup=jinjaCommentDelim start="{#" end="#}" containedin=ALLBUT,jinjaTagBlock,jinjaVarBlock,jinjaString
+
+" Block start keywords.  A bit tricker.  We only highlight at the start of a
+" tag block and only if the name is not followed by a comma or equals sign
+" which usually means that we have to deal with an assignment.
+syn match jinjaStatement containedin=jinjaTagBlock contained skipwhite /\({%-\?\s*\)\@<=\<[a-zA-Z_][a-zA-Z0-9_]*\>\(\s*[,=]\)\@!/
+
+" and context modifiers
+syn match jinjaStatement containedin=jinjaTagBlock contained /\<with\(out\)\?\s\+context\>/ skipwhite
+
+
+" Define the default highlighting.
+" For version 5.7 and earlier: only when not done already
+" For version 5.8 and later: only when an item doesn't have highlighting yet
+if version >= 508 || !exists("did_jinja_syn_inits")
+  if version < 508
+    let did_jinja_syn_inits = 1
+    command -nargs=+ HiLink hi link <args>
+  else
+    command -nargs=+ HiLink hi def link <args>
+  endif
+
+  HiLink jinjaPunctuation jinjaOperator
+  HiLink jinjaAttribute jinjaVariable
+  HiLink jinjaFunction jinjaFilter
+
+  HiLink jinjaTagDelim jinjaTagBlock
+  HiLink jinjaVarDelim jinjaVarBlock
+  HiLink jinjaCommentDelim jinjaComment
+  HiLink jinjaRawDelim jinja
+
+  HiLink jinjaSpecial Special
+  HiLink jinjaOperator Normal
+  HiLink jinjaRaw Normal
+  HiLink jinjaTagBlock PreProc
+  HiLink jinjaVarBlock PreProc
+  HiLink jinjaStatement Statement
+  HiLink jinjaFilter Function
+  HiLink jinjaBlockName Function
+  HiLink jinjaVariable Identifier
+  HiLink jinjaString Constant
+  HiLink jinjaNumber Constant
+  HiLink jinjaComment Comment
+
+  delcommand HiLink
+endif
+
+let b:current_syntax = "jinja"

--- a/syntax/yaml.vim
+++ b/syntax/yaml.vim
@@ -1,0 +1,61 @@
+" To make this file do stuff, add something like the following (without the
+" leading ") to your ~/.vimrc:
+" au BufNewFile,BufRead *.yaml,*.yml so ~/src/PyYaml/YAML.vim
+
+" Vim syntax/macro file
+" Language: YAML
+" Author:   Igor Vergeichik <iverg@mail.ru>
+" Sponsor: Tom Sawyer <transami@transami.net>
+" Stayven: Ryan King <jking@panoptic.com>
+" Copyright (c) 2002 Tom Saywer
+
+" Add an item to a gangly list:
+"map , o<bs><bs><bs><bs>-<esc>o
+" Convert to Canonical form:
+"map \c :%!python -c 'from yaml.redump import redump; import sys; print redump(sys.stdin.read()).rstrip()'
+
+if version < 600
+  syntax clear
+elseif exists("b:current_syntax")
+  finish
+endif
+syntax clear
+
+syn match yamlDelimiter "[:,-]"
+syn match yamlBlock "[\[\]\{\}\|\>]"
+syn match yamlOperator "[?^+-]\|=>"
+
+syn region yamlComment  start="\#" end="$"
+syn match yamlIndicator "#YAML:\S\+"
+
+syn region yamlString   start="'" end="'" skip="\\'"
+syn region yamlString   start='"' end='"' skip='\\"' contains=yamlEscape
+syn match  yamlEscape   +\\[abfnrtv'"\\]+ contained
+syn match  yamlEscape   "\\\o\o\=\o\=" contained
+syn match  yamlEscape   "\\x\x\+" contained
+
+syn match  yamlType "!\S\+"
+
+syn keyword yamlConstant NULL Null null NONE None none NIL Nil nil
+syn keyword yamlConstant TRUE True true YES Yes yes ON On on
+syn keyword yamlConstant FALSE False false NO No no OFF Off off
+
+syn match  yamlKey  "\w\+\ze\s*:"
+syn match  yamlAnchor   "&\S\+"
+syn match  yamlAlias    "*\S\+"
+
+" Setupt the hilighting links
+
+hi link yamlConstant Keyword
+hi link yamlIndicator PreCondit
+hi link yamlAnchor  Function
+hi link yamlAlias   Function
+hi link yamlKey     Identifier
+hi link yamlType    Type
+
+hi link yamlComment Comment
+hi link yamlBlock   Operator
+hi link yamlOperator    Operator
+hi link yamlDelimiter   Delimiter
+hi link yamlString  String
+hi link yamlEscape  Special


### PR DESCRIPTION
This is the jinja syntax file as recommended in [Jinja Integration](http://jinja.pocoo.org/docs/dev/integration/#vim), helps in editing map.jinja files as long as modeline is setup and ft is set to jinja:
```
# -*- coding: utf-8 -*-
# vim: ft=jinja
```


If there is a better way to do this, please let me know, I have kept all the original comments/copyright from the author at [vim scripts page](http://www.vim.org/scripts/script.php?script_id=1856).