### PR TITLE
Fixed Jinja syntax autodetection to work independently of Pathogen.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,13 +43,12 @@ show all such paths. Read ``:help runtimepath`` for more info.
 Configuration
 =============
 
-By default, if Pathogen is installed, the syntax file will search for the
-existence of a Jinja syntax file (as described in the `Jinja docs`_ or via a
-`Vim bundle`_) in the ``runtimepath``, and load that if found. If it is not
-found or Pathogen is not installed, the Django template syntax file (which is
-slightly different, but bundled with Vim) will be used. You can force using
-either syntax file using the global variable ``g:sls_use_jinja_syntax``. If it
-is set, autodetection will be turned off.
+By default, the syntax file will search for the existence of a Jinja syntax
+file (as described in the `Jinja docs`_ or via a `Vim bundle`_) in the
+``runtimepath``, and load that if found. If it is not found, the Django
+template syntax file (which is slightly different, but bundled with Vim) will
+be used. You can force using either syntax file using the global variable
+``g:sls_use_jinja_syntax``. If it is set, autodetection will be turned off.
 
 .. _Jinja docs: http://jinja.pocoo.org/docs/integration/#vim
 .. _Vim bundle: https://github.com/Glench/Vim-Jinja2-Syntax

--- a/syntax/sls.vim
+++ b/syntax/sls.vim
@@ -28,9 +28,9 @@ let s:search_for_jinja_syntax = 1
 if exists("g:sls_use_jinja_syntax")
   let s:search_for_jinja_syntax = 0
   let s:load_jinja_syntax = g:sls_use_jinja_syntax
-end
-if s:search_for_jinja_syntax && exists("*pathogen#runtime_findfile")
-  let s:jinja_path = pathogen#runtime_findfile("syntax/jinja.vim", 1)
+endif
+if s:search_for_jinja_syntax
+  let s:jinja_path = findfile("syntax/jinja.vim", &rtp, 1)
   if s:jinja_path != ""
     let s:load_jinja_syntax = 1
   endif


### PR DESCRIPTION
Channged the Jinja syntax autodetecion to use built-in Vim functions,
instead of using Pathogen's functions. This allows Jinja syntax
autodetection to work with Vundle or without a plugin manager.
README.rst has been updated accordingly.